### PR TITLE
Convert CLI parsing to cobra

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/werkshy/likeness/index"
+)
+
+// indexCmd represents the index command
+var indexCmd = &cobra.Command{
+	Use:   "index",
+	Short: "Build or update the index of your photo directory",
+	Long:  `Walk through the directory, indexing files into the DB using md5sums.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		index.StartIndex(mainDir, dbConnection)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(indexCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"log"
+	"os"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/spf13/cobra"
+	"github.com/werkshy/likeness/schema"
+)
+
+var mainDir string
+var dbURL string
+var dbConnection *sqlx.DB
+
+// RootCmd implements main 'root' cobra arg parsing, for args that
+// apply to all subcommands.
+var RootCmd = &cobra.Command{
+	Use:   "likeness",
+	Short: "Likeness is a photo importer and organizer",
+	Long:  `Import, organize, detect duplicated photo files.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		checkConfig()
+		dbConnection = createDbConnection()
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Printf("Yo\n")
+	},
+}
+
+func init() {
+	flags := RootCmd.PersistentFlags()
+	flags.StringVar(&mainDir, "main-dir", "/home/oneill/test-photos", "Main Photo Directory")
+
+	flags.StringVar(&dbURL, "db-url", "postgres://localhost:5432/likeness", "Postgres DB Url")
+	//var thumbDir = flag.String("thumb-dir", "/.thumbs", "Relative Path of Thumbnail storage")
+}
+
+func checkConfig() {
+	if _, err := os.Stat(mainDir); os.IsNotExist(err) {
+		log.Fatalf("Main directory '%s' does not exist\n", mainDir)
+	} else {
+		log.Printf("Main dir: %s\n", mainDir)
+	}
+}
+
+func createDbConnection() (db *sqlx.DB) {
+	db = sqlx.MustConnect("postgres", dbURL)
+	schema.Migrate(db)
+	return
+}

--- a/main.go
+++ b/main.go
@@ -1,67 +1,17 @@
 package main
 
 import (
-	"flag"
 	"fmt"
-	"log"
 	"os"
-
-	"github.com/jmoiron/sqlx"
 
 	_ "github.com/lib/pq"
 
-	"github.com/werkshy/likeness/index"
-	"github.com/werkshy/likeness/schema"
+	"github.com/werkshy/likeness/cmd"
 )
 
-// Global config variables
-var mainDir string
-
-func usage() {
-	fmt.Println("Usage: likeness COMMAND [ARGS]")
-	fmt.Println("COMMAND is one of:")
-	fmt.Println("  index: index existing photo dir")
-	fmt.Println("ARGS and their default values:")
-	flag.PrintDefaults()
-	os.Exit(2)
-}
-
 func main() {
-	log.SetFlags(log.LstdFlags | log.Lshortfile)
-	flag.StringVar(&mainDir, "main-dir", "/home/oneill/test-photos", "Main Photo Directory")
-
-	var dbUrl = flag.String("db-url", "postgres://localhost:5432/likeness", "Postgres DB Url")
-	//var thumbDir = flag.String("thumb-dir", "/.thumbs", "Relative Path of Thumbnail storage")
-
-	// TODO: add http server flags
-	flag.Parse()
-
-	// Verify that a subcommand has been provided
-	// os.Arg[0] is the main command
-	// os.Arg[1] will be the subcommand
-	if len(os.Args) < 2 {
-		usage()
+	if err := cmd.RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
-	var command = os.ExpandEnv(flag.Arg(0))
-
-	checkConfig(mainDir)
-
-	db := sqlx.MustConnect("postgres", *dbUrl)
-	schema.Migrate(db)
-
-	switch command {
-	case "index":
-		index.StartIndex(mainDir, db)
-	default:
-		log.Fatalf("Unknown command: '%s'\n", command)
-	}
-}
-
-func checkConfig(mainDir string) {
-	if _, err := os.Stat(mainDir); os.IsNotExist(err) {
-		log.Fatalf("Main directory '%s' does not exist\n", mainDir)
-	} else {
-		log.Printf("Main dir: %s\n", mainDir)
-	}
-
 }


### PR DESCRIPTION
The [cobra CLI parsing framework](https://github.com/spf13/cobra) gives us root config vars (e.g. main-
dir), subcommands (e.g. index, serve, import) and per-subcommand config vars.

It also has a config file format that might be handy later. It is well used and well liked!